### PR TITLE
GPX-300 Optional argument support added to filetypes_count.sh

### DIFF
--- a/filetypes_count.sh
+++ b/filetypes_count.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 EXTENSION=$1
-DIR=$2
+DIR=${2:-.}
 
 WILDCARD_PATH="$DIR/*.$EXTENSION"
 COUNT=0


### PR DESCRIPTION
- The program by default assumes the current working directory as the second argument if it is not provided